### PR TITLE
Bind admin UI to 0.0.0.0

### DIFF
--- a/packages/strapi/lib/commands/watchAdmin.js
+++ b/packages/strapi/lib/commands/watchAdmin.js
@@ -17,7 +17,7 @@ module.exports = async function({ browser }) {
   const { adminPath } = getConfigUrls(config.get('server'), true);
 
   const adminPort = config.get('server.admin.port', 8000);
-  const adminHost = config.get('server.admin.host', 'localhost');
+  const adminHost = config.get('server.admin.host', '0.0.0.0');
   const adminWatchIgnoreFiles = config.get('server.admin.watchIgnoreFiles', []);
 
   strapiAdmin.watchAdmin({


### PR DESCRIPTION
Bind admin UI to 0.0.0.0 to allow Docker containers to properly forward to that port.


### What does it do?

Binding port 8000 to `0.0.0.0` instead of `localhost`.

### Why is it needed?

In order for Docker containers to be able to forward to that port. Docker can't forward to ports that are bound to localhost.

### Related issue(s)/PR(s)

None.
